### PR TITLE
Fix buffer issue on Windows 10

### DIFF
--- a/pyboinc/_raw_client.py
+++ b/pyboinc/_raw_client.py
@@ -32,7 +32,7 @@ class _RPCClientRaw:
         self._reader = self._writer = None
 
     async def connect(self):
-        self._reader, self._writer = await asyncio.open_connection(self.host, self.port, family=AF_INET)
+        self._reader, self._writer = await asyncio.open_connection(self.host, self.port, family=AF_INET, limit=1024*5000)
 
     async def _write(self, message: bytes):
         if self._writer is None:


### PR DESCRIPTION
Solves this issue which was occurring on Windows but not Linux. Been loving this library thank you for publishing it!

  File "C:\Users\user\Desktop\FindTheMag\libs\pyboinc\rpc_client.py", line 142, in get_project_status
    return [Project(**parse_generic(c)) for c in await self._request(req)]
  File "C:\Users\user\Desktop\FindTheMag\libs\pyboinc\rpc_client.py", line 78, in _request
    return await self._raw_client.request(req)
  File "C:\Users\user\Desktop\FindTheMag\libs\pyboinc\_raw_client.py", line 82, in request
    return await self.receive()
  File "C:\Users\user\Desktop\FindTheMag\libs\pyboinc\_raw_client.py", line 63, in receive
    buff = [await self._read()]
  File "C:\Users\user\Desktop\FindTheMag\libs\pyboinc\_raw_client.py", line 57, in _read
    return await self._reader.readuntil(separator=END_OF_MESSAGE)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\asyncio\streams.py", line 620, in readuntil
    raise exceptions.LimitOverrunError(
asyncio.exceptions.LimitOverrunError: Separator is found, but chunk is longer than limit